### PR TITLE
Fix endless sign in ff and safari

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -86,7 +86,7 @@ function App() {
           </Nav>
         </Container>
       </Navbar>
-      <Container className="d-flex flex-column min-vh-100 justify-content-center align-items-center">
+      <Container className="d-flex flex-column justify-content-center align-items-center my-5">
         <Form onSubmit={handleSubmit}>
           <Form.Group className="mb-3">
             <Form.Label>Email Address</Form.Label>

--- a/main.go
+++ b/main.go
@@ -141,7 +141,16 @@ func callbackHandler(oauth2Config *oauth2.Config, cfg *config.Config, verifier *
 			HttpOnly: true,
 			Path:     "/",
 		})
-		http.Redirect(w, r, "/", http.StatusFound)
+
+		// Firefox and Safari don't set the jwt cookie when using SameSite=strict right after the redirect.
+		// Resulting in an endless sign in loop. This can be fixed with SameSite=lax (not the same security)
+		// or using client side redirect. See below!
+		fmt.Fprint(w,
+			`<!DOCTYPE html>
+			<html>
+				<head><meta http-equiv="refresh" content="0; url='/'"></head>
+				<body></body>
+			</html>`)
 
 		return
 	}


### PR DESCRIPTION
Both of these browsers don't set the cookie right after the redirect
from the callback url. Apparently this happens when SameSite=strict.
To keep strict mode, we work around with a client side redirect.
See: https://stackoverflow.com/a/71467131
