### PR TITLE
Check pin strength

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	Nuki struct {
 		APIKey          string `yaml:"apiKey"`
 		SmartLockDevice int64  `yaml:"smartLockDevice"`
+		// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
+		MinimumPinEntropy float64 `yaml:"minimumPinEntropy,omitempty"`
 	} `yaml:"nuki"`
 	StorageType string `yaml:"storageType"`
 	Redis       struct {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/spf13/pflag v1.0.5
+	github.com/wagslane/go-password-validator v0.3.0
 	golang.org/x/oauth2 v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -319,6 +319,8 @@ github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/wagslane/go-password-validator v0.3.0 h1:vfxOPzGHkz5S146HDpavl0cw1DSVP061Ry2PX0/ON6I=
+github.com/wagslane/go-password-validator v0.3.0/go.mod h1:TI1XJ6T5fRdRnHqHt14pvy1tNVnrwe7m3/f1f2fDphQ=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=


### PR DESCRIPTION
Don't allow weak pins. This can also be configured. But at the moment,
Pins like 111111 are possible. Other weak Pins like 123456 are denied by
the Nuki API, but now we could already fail earlier.
