### PR TITLE
Option to allow monotonic pins (default: false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ type Config struct {
 		// SmartLockDevice is the ID of the nuki smart lock.
 		SmartLockDevice int64 `yaml:"smartLockDevice"`
 		// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
+		// We use https://github.com/wagslane/go-password-validator, which can return confusing results.
+		// For example 112233 and 938163 have the same entropy.
 		MinimumPinEntropy float64 `yaml:"minimumPinEntropy,omitempty"`
+		// AllowMonotonousPins will allow Pins like 123456, 122334 or 654321, 662211, ...
+		AllowMonotonicPins bool `yaml:"allowMonotonicPins,omitempty"`
 	} `yaml:"nuki"`
 	// StorageType for the state generated in the oauth2 flow. Options are memory or redis.
 	StorageType string `yaml:"storageType"`

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,11 @@ type Config struct {
 		// SmartLockDevice is the ID of the nuki smart lock.
 		SmartLockDevice int64 `yaml:"smartLockDevice"`
 		// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
+		// We use https://github.com/wagslane/go-password-validator, which can return confusing results.
+		// For example 112233 and 938163 have the same entropy.
 		MinimumPinEntropy float64 `yaml:"minimumPinEntropy,omitempty"`
+		// AllowMonotonousPins will allow Pins like 123456, 122334 or 654321, 662211, ...
+		AllowMonotonicPins bool `yaml:"allowMonotonicPins,omitempty"`
 	} `yaml:"nuki"`
 	// StorageType for the state generated in the oauth2 flow. Options are memory or redis.
 	StorageType string `yaml:"storageType"`

--- a/server_test.go
+++ b/server_test.go
@@ -30,7 +30,8 @@ func TestUpdatePin(t *testing.T) {
 			APIKey          string `yaml:"apiKey"`
 			SmartLockDevice int64  `yaml:"smartLockDevice"`
 			// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
-			MinimumPinEntropy float64 `yaml:"minimumPinEntropy,omitempty"`
+			MinimumPinEntropy  float64 `yaml:"minimumPinEntropy,omitempty"`
+			AllowMonotonicPins bool    `yaml:"allowMonotonicPins,omitempty"`
 		}{
 			MinimumPinEntropy: 10,
 		},


### PR DESCRIPTION
Nuki seems to quietly ignore creation or updating of codes that are
monotonic. For example 112233 or 332211.
I am not sure if this is true for all key pads, so I added an option to
allow them, but by default those requests will return an error to the
user.
