### PR TITLE
feat: configure multiple smartlock devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ type Config struct {
 	Nuki struct {
 		// APIKey is the Nuki API token
 		APIKey string `yaml:"apiKey"`
-		// SmartLockDevice is the ID of the nuki smart lock.
-		SmartLockDevice int64 `yaml:"smartLockDevice"`
+		// (Depracated) SmartLockDevice is the ID of the nuki smart lock. Use SmartLockDevices instead
+		SmartLockDevice int64 `yaml:"smartLockDevice,omitempty"`
+		// SmartLockDevices is the list of ID of the nuki smart locks to manage. They are all updated with the same pin.
+		// At least one SmartLockDevice ID must be set.
+		SmartLockDevices []int64 `yaml:"smartLockDevices,omitempty"`
 		// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
 		// We use https://github.com/wagslane/go-password-validator, which can return confusing results.
 		// For example 112233 and 938163 have the same entropy.

--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,11 @@ type Config struct {
 	Nuki struct {
 		// APIKey is the Nuki API token
 		APIKey string `yaml:"apiKey"`
-		// SmartLockDevice is the ID of the nuki smart lock.
-		SmartLockDevice int64 `yaml:"smartLockDevice"`
+		// (Depracated) SmartLockDevice is the ID of the nuki smart lock. Use SmartLockDevices instead
+		SmartLockDevice int64 `yaml:"smartLockDevice,omitempty"`
+		// SmartLockDevices is the list of ID of the nuki smart locks to manage. They are all updated with the same pin.
+		// At least one SmartLockDevice ID must be set.
+		SmartLockDevices []int64 `yaml:"smartLockDevices,omitempty"`
 		// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
 		// We use https://github.com/wagslane/go-password-validator, which can return confusing results.
 		// For example 112233 and 938163 have the same entropy.

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/vektra/mockery/v2 v2.20.0
 	github.com/wagslane/go-password-validator v0.3.0
 	golang.org/x/oauth2 v0.13.0
+	golang.org/x/sync v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/main.go
+++ b/main.go
@@ -65,6 +65,21 @@ func main() {
 		}
 	}
 
+	if len(cfg.Nuki.SmartLockDevices) == 0 && cfg.Nuki.SmartLockDevice == 0 {
+		log.Fatal("no smart lock device configured")
+	}
+
+	if cfg.Nuki.SmartLockDevice != 0 {
+		log.Println("smartLockDevice is deprecated, use smartLockDevices instead")
+		if len(cfg.Nuki.SmartLockDevices) != 0 {
+			log.Fatal("SmartLockDevices is already set, remove SmartLockDevice from the config file")
+		}
+	}
+	// Retro compatibility
+	if len(cfg.Nuki.SmartLockDevices) == 0 {
+		cfg.Nuki.SmartLockDevices = append(cfg.Nuki.SmartLockDevices, cfg.Nuki.SmartLockDevice)
+	}
+
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector(), collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 

--- a/server_test.go
+++ b/server_test.go
@@ -27,15 +27,17 @@ import (
 func TestUpdatePin(t *testing.T) {
 	cfg := &config.Config{
 		Nuki: struct {
-			APIKey          string `yaml:"apiKey"`
-			SmartLockDevice int64  `yaml:"smartLockDevice"`
+			APIKey           string  `yaml:"apiKey"`
+			SmartLockDevice  int64   `yaml:"smartLockDevice,omitempty"`
+			SmartLockDevices []int64 `yaml:"smartLockDevices,omitempty"`
 			// MinimumPinEntropy is the mimimum entropy needed by a pin to be accepted (default: 10)
 			MinimumPinEntropy  float64 `yaml:"minimumPinEntropy,omitempty"`
 			AllowMonotonicPins bool    `yaml:"allowMonotonicPins,omitempty"`
-			AllowedFromTime *int `yaml:"allowedFromTime,omitempty"`
-			AllowedUntilTime *int `yaml:"allowedUntilTime,omitempty"`
-			AllowedWeekDays int `yaml:"allowedWeekDays,omitempty"`
+			AllowedFromTime    *int    `yaml:"allowedFromTime,omitempty"`
+			AllowedUntilTime   *int    `yaml:"allowedUntilTime,omitempty"`
+			AllowedWeekDays    int     `yaml:"allowedWeekDays,omitempty"`
 		}{
+			SmartLockDevices:  []int64{1111, 2222},
 			MinimumPinEntropy: 10,
 		},
 	}


### PR DESCRIPTION
For the scenario of multiple doors being secured, each of the lock are updated.

- Deprecate `SmartLockDevice` in favor of a new array `SmartLockDevices` to handle multiple devices in `config.go`
- Implement compatibility code to support both the new `SmartHangDevices` array and the deprecated single device config in `server.go`